### PR TITLE
Update files for Netlify CMS Identity support for #12

### DIFF
--- a/app/_includes/_html-header.pug
+++ b/app/_includes/_html-header.pug
@@ -36,3 +36,6 @@ head
 
   // Stylesheets
   link(href='/styles/main.css', rel='stylesheet')
+
+  // Netlify identity
+  script(src='https://identity.netlify.com/v1/netlify-identity-widget.js')

--- a/app/_layouts/_main.pug
+++ b/app/_layouts/_main.pug
@@ -52,3 +52,15 @@ html(language='en')
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-XXXXX-X', 'auto');
       ga('send', 'pageview');
+
+    // Netlify Identity widget
+    script.
+      if (window.netlifyIdentity) {
+        window.netlifyIdentity.on('init', function(user) {
+          if (!user) {
+            window.netlifyIdentity.on('login', function() {
+              document.location.href = '/admin/';
+            });
+          }
+        });
+      }

--- a/app/admin/config.yml
+++ b/app/admin/config.yml
@@ -1,5 +1,5 @@
 backend:
-  name: github
+  name: git-gateway # Necessary API for authenticating users: https://www.netlifycms.org/docs/add-to-your-site/#configuration
   repo: # Example: bsd/static-starterkit
   branch: master # Branch to update (master by default)
 

--- a/app/admin/index.html
+++ b/app/admin/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.6/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.css" />
   <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^0.6/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
 </body>
 </html>

--- a/app/admin/index.html
+++ b/app/admin/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.4/dist/cms.css" />
-
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^0.6/dist/cms.css" />
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^0.4/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^0.6/dist/cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
1. Upgrade CMS to v0.6 (otherwise results in errors communicating to config backend)
2. Add identity scripts to the necessary templates. Should now only need to be enabled in the Identity settings */sites/[sitename]/settings/identity

https://github.com/bsd/static-starterkit/issues/12 