### PR TITLE
Updating Markdown Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-imagemin": "^2.4.0",
     "gulp-jsoncombine": "^1.0.3",
     "gulp-load-plugins": "^1.2.4",
-    "gulp-markdown-to-json": "^1.0.3",
+    "gulp-markdown-to-json": "~1.0.3",
     "gulp-merge-json": "^1.0.0",
     "gulp-newer": "^1.2.0",
     "gulp-plumber": "^1.1.0",


### PR DESCRIPTION
As per KM changes.  This needs to be changed in the template.  Higher version of Markdown breaks build process.